### PR TITLE
Reregister instances when delegateHandle changes

### DIFF
--- a/src/js/pdf-ctrl.js
+++ b/src/js/pdf-ctrl.js
@@ -9,6 +9,13 @@ angular.module('pdf')
 
     // Register the instance!
     var deregisterInstance = pdfDelegate._registerInstance(this, $attrs.delegateHandle);
+    
+    // De-register and Re-register when the id (delegateHandle) changes
+    $scope.$watch(function() { return $scope.id }, function(value) {
+        deregisterInstance();
+        deregisterInstance = pdfDelegate._registerInstance(self, value);
+    });
+    
     // De-Register on destory!
     $scope.$on('$destroy', deregisterInstance);
 


### PR DESCRIPTION
De-register and Re-register when the id (delegateHandle) changes. This is useful when you would like to set the delegateHandle in a dynamic way, like the following:

```html
<pdf-viewer url="/my.pdf" delegate-handle="{{pdfId}}"></pdf-viewer>
```