### PR TITLE
Return a promise from the PdfCtrl.load() method.

### DIFF
--- a/src/js/pdf-ctrl.js
+++ b/src/js/pdf-ctrl.js
@@ -119,7 +119,7 @@ angular.module('pdf')
         docInitParams.url = url;
       }
 
-      PDFJS
+      return PDFJS
         .getDocument(docInitParams)
         .then(function (_pdfDoc) {
 


### PR DESCRIPTION
It allows for chaining of the promise. That way the user can get for instance the pageCount after the PDF has been loaded. Instead of guesstimating the load of the pdf with $timeout.